### PR TITLE
add NaN check to Util.assertNumber

### DIFF
--- a/src/lib/util.coffee
+++ b/src/lib/util.coffee
@@ -6,7 +6,7 @@ class Util
         if not val?
             throw new Error(desc + ' is required.')
 
-        if typeof val isnt 'number'
+        if typeof val isnt 'number' or isNaN val
             throw new Error(desc + ' must be a number.')
 
 


### PR DESCRIPTION
Sadly, typeof NaN === 'number', so if you pass NaN to any constructors in this module the behavior can go very badly wrong without any errors being thrown.
